### PR TITLE
ci: pin benchmark baselines to gersemi 0.27.7 and cmakelang 0.6.13

### DIFF
--- a/.github/workflows/benchmark-fixtures.yml
+++ b/.github/workflows/benchmark-fixtures.yml
@@ -214,7 +214,7 @@ jobs:
         if: steps.plan.outputs.skip != 'true' && steps.check_baselines.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          pip install cmakelang gersemi pytest pytest-benchmark
+          pip install cmakelang==0.6.13 gersemi==0.27.7 pytest pytest-benchmark
 
       - name: Run cmake_format baseline
         if: steps.plan.outputs.skip != 'true' && steps.check_baselines.outputs.skip != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ bun run preview                          # preview production build
 - Code formatting: `dprint` orchestrates all file types — `rustfmt --edition 2024` for `.rs` via exec plugin
 - No custom `rustfmt.toml` / `clippy.toml`; rely on defaults + `clippy -D warnings`
 - Conventional commits enforced by cocogitto (`cog verify`), changelog via git-cliff
+  - Use the `feat` type only for genuine new features — it drives a minor version bump and a changelog "Features" entry. Default to the precise type for the change (`fix`, `refactor`, `docs`, `test`, `chore`, etc.) and reserve `feat` for when a feature is actually added.
 - Pre-commit hooks: `hk` (Pkl config) — cargo-fmt, cargo-clippy, dprint, actionlint, etc.
 - JS runtime/tooling: use `bun` / `bun x` — never `node`, `npm`, or `npx`
 


### PR DESCRIPTION
Pin the baseline benchmark tools to their latest releases so the published comparison reflects current versions:

- gersemi `0.26.1` → `0.27.7`
- cmakelang stays at `0.6.13` (latest; no release since 2020), now pinned explicitly

Only the `Install baseline benchmark tools` step changes. `pytest`/`pytest-benchmark` (harness, not measured) left unpinned. No bench-script changes needed — the gersemi 0.27.7 API (`create_formatter`, `Formatter.format`) is compatible with `scripts/bench_gersemi_baseline.py`. A manual `workflow_dispatch` after merge re-measures both baselines.